### PR TITLE
Make units not overlap when moving to the same map square

### DIFF
--- a/mike-and-conquer/GameState/PlayingGameState.cs
+++ b/mike-and-conquer/GameState/PlayingGameState.cs
@@ -319,10 +319,10 @@ namespace mike_and_conquer
                     {
                         BasicMapSquare clickedBasicMapSquare =
                             MikeAndConquerGame.instance.FindMapSquare(mouseX, mouseY);
-                        //                        Point centerOfSquare = clickedBasicMapSquare.GetCenter();
-                        //                        nextMinigunner.OrderToMoveToDestination(centerOfSquare);
-                        Point destinationPoint = clickedBasicMapSquare.GetNextAvailableMinigunnerPosition();
-                        nextMinigunner.OrderToMoveToDestination(destinationPoint);
+                        Point centerOfSquare = clickedBasicMapSquare.GetCenter();
+                        nextMinigunner.OrderToMoveToDestination(centerOfSquare);
+//                        Point destinationPoint = clickedBasicMapSquare.GetNextAvailableMinigunnerPosition();
+                        nextMinigunner.OrderToMoveToDestination(centerOfSquare);
 
                     }
                 }

--- a/mike-and-conquer/GameState/PlayingGameState.cs
+++ b/mike-and-conquer/GameState/PlayingGameState.cs
@@ -321,7 +321,6 @@ namespace mike_and_conquer
                             MikeAndConquerGame.instance.FindMapSquare(mouseX, mouseY);
                         Point centerOfSquare = clickedBasicMapSquare.GetCenter();
                         nextMinigunner.OrderToMoveToDestination(centerOfSquare);
-                        nextMinigunner.OrderToMoveToDestination(centerOfSquare);
                     }
                 }
             }

--- a/mike-and-conquer/GameState/PlayingGameState.cs
+++ b/mike-and-conquer/GameState/PlayingGameState.cs
@@ -319,8 +319,11 @@ namespace mike_and_conquer
                     {
                         BasicMapSquare clickedBasicMapSquare =
                             MikeAndConquerGame.instance.FindMapSquare(mouseX, mouseY);
-                        Point centerOfSquare = clickedBasicMapSquare.GetCenter();
-                        nextMinigunner.OrderToMoveToDestination(centerOfSquare);
+                        //                        Point centerOfSquare = clickedBasicMapSquare.GetCenter();
+                        //                        nextMinigunner.OrderToMoveToDestination(centerOfSquare);
+                        Point destinationPoint = clickedBasicMapSquare.GetNextAvailableMinigunnerPosition();
+                        nextMinigunner.OrderToMoveToDestination(destinationPoint);
+
                     }
                 }
             }

--- a/mike-and-conquer/GameState/PlayingGameState.cs
+++ b/mike-and-conquer/GameState/PlayingGameState.cs
@@ -321,9 +321,7 @@ namespace mike_and_conquer
                             MikeAndConquerGame.instance.FindMapSquare(mouseX, mouseY);
                         Point centerOfSquare = clickedBasicMapSquare.GetCenter();
                         nextMinigunner.OrderToMoveToDestination(centerOfSquare);
-//                        Point destinationPoint = clickedBasicMapSquare.GetNextAvailableMinigunnerPosition();
                         nextMinigunner.OrderToMoveToDestination(centerOfSquare);
-
                     }
                 }
             }

--- a/mike-and-conquer/gameobjects/Minigunner.cs
+++ b/mike-and-conquer/gameobjects/Minigunner.cs
@@ -138,52 +138,18 @@ namespace mike_and_conquer
 
         }
 
-
         private void LandOnFinalDestinationMapSquare(GameTime gameTime)
         {
-
 
             if (this.state == State.MOVING)
             {
 
-                Point currentDestinationPoint = path[0];
+                Point centerOfDestinationSquare = path[0];
 
                 BasicMapSquare destinationBasicMapSquare =
-                    MikeAndConquerGame.instance.FindMapSquare(currentDestinationPoint.X, currentDestinationPoint.Y);
+                    MikeAndConquerGame.instance.FindMapSquare(centerOfDestinationSquare.X, centerOfDestinationSquare.Y);
 
-                Pickup here:  Everything is basicially working for up to moving 5 units
-                Next steps:  Refactor and cleanup
-                  Then determine how to handle 10
-
-                if (destinationBasicMapSquare.numSlotsOccupied == 0)
-                {
-                    currentDestinationPoint.X = currentDestinationPoint.X + 4;
-                    currentDestinationPoint.Y = currentDestinationPoint.Y - 3;
-                }
-                else if (destinationBasicMapSquare.numSlotsOccupied == 1)
-                {
-                    currentDestinationPoint.X = currentDestinationPoint.X - 8;
-                    currentDestinationPoint.Y = currentDestinationPoint.Y - 3;
-                }
-                else if (destinationBasicMapSquare.numSlotsOccupied == 2)
-                {
-                    currentDestinationPoint.X = currentDestinationPoint.X + 4;
-                    currentDestinationPoint.Y = currentDestinationPoint.Y + 10;
-                }
-                else if (destinationBasicMapSquare.numSlotsOccupied == 3)
-                {
-                    currentDestinationPoint.X = currentDestinationPoint.X - 8;
-                    currentDestinationPoint.Y = currentDestinationPoint.Y + 10;
-                }
-                else if (destinationBasicMapSquare.numSlotsOccupied == 4)
-                {
-                    currentDestinationPoint.X = currentDestinationPoint.X - 2;
-                    currentDestinationPoint.Y = currentDestinationPoint.Y + 3;
-                }
-
-
-                destinationBasicMapSquare.numSlotsOccupied++;
-
+                Point currentDestinationPoint = destinationBasicMapSquare.GetDestinationSlotForMinigunner(this);
                 SetDestination(currentDestinationPoint.X, currentDestinationPoint.Y);
 
             }

--- a/mike-and-conquer/gameobjects/Minigunner.cs
+++ b/mike-and-conquer/gameobjects/Minigunner.cs
@@ -385,6 +385,12 @@ namespace mike_and_conquer
 
         public void OrderToMoveToDestination(Point destination)
         {
+
+            BasicMapSquare currentMapSquareLocation =
+                MikeAndConquerGame.instance.FindMapSquare((int)this.positionInWorldCoordinates.X,
+                    (int) this.positionInWorldCoordinates.Y);
+
+            currentMapSquareLocation.ClearSlotForMinigunner(this);
             int startColumn = (int)this.positionInWorldCoordinates.X / 24;
             int startRow = (int)this.positionInWorldCoordinates.Y / 24;
             Point startPoint = new Point(startColumn, startRow);

--- a/mike-and-conquer/gameobjects/Minigunner.cs
+++ b/mike-and-conquer/gameobjects/Minigunner.cs
@@ -1,7 +1,6 @@
 ﻿
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using mike_and_conquer.gameview;
 using mike_and_conquer.pathfinding;
 using Vector2 = Microsoft.Xna.Framework.Vector2;
@@ -40,12 +39,10 @@ namespace mike_and_conquer
         public enum Command { NONE,  ATTACK_TARGET, FOLLOW_PATH };
         public Command currentCommand;
 
-
         private int destinationX;
         private int destinationY;
 
         public Vector2 DestinationPosition { get { return new Vector2(destinationX, destinationY); } }
-
 
         private List<Point> path;
 
@@ -143,7 +140,6 @@ namespace mike_and_conquer
 
             if (this.state == State.MOVING)
             {
-
                 Point centerOfDestinationSquare = path[0];
 
                 BasicMapSquare destinationBasicMapSquare =
@@ -176,6 +172,11 @@ namespace mike_and_conquer
             }
             else if (path.Count == 1)
             {
+
+                // TODO:  Currently waiting until units almost arrive to assign
+                // them slots on the destination square, but when
+                // handling more than 5 units, will probably need to assign slots
+                // when the move is initiated, rather than up on arrival
                 LandOnFinalDestinationMapSquare(gameTime);
             }
             else

--- a/mike-and-conquer/gameview/BasicMapSquare.cs
+++ b/mike-and-conquer/gameview/BasicMapSquare.cs
@@ -119,8 +119,33 @@ namespace mike_and_conquer.gameview
             }
 
             return nextAvailablePosition;
+        }
+
+        internal void ClearSlotForMinigunner(Minigunner aMinigunner)
+        {
+            if (minigunnerSlot0 == aMinigunner)
+            {
+                minigunnerSlot0 = null;
+            }
+            if (minigunnerSlot1 == aMinigunner)
+            {
+                minigunnerSlot1 = null;
+            }
+            if (minigunnerSlot2 == aMinigunner)
+            {
+                minigunnerSlot2 = null;
+            }
+            if (minigunnerSlot3 == aMinigunner)
+            {
+                minigunnerSlot3 = null;
+            }
+            if (minigunnerSlot4 == aMinigunner)
+            {
+                minigunnerSlot4 = null;
+            }
 
         }
+
 
         public bool IsBlockingTerrain()
         {

--- a/mike-and-conquer/gameview/BasicMapSquare.cs
+++ b/mike-and-conquer/gameview/BasicMapSquare.cs
@@ -1,5 +1,6 @@
 ﻿
 
+using System;
 using System.Linq;
 using AnimationSequence = mike_and_conquer.util.AnimationSequence;
 
@@ -21,9 +22,19 @@ namespace mike_and_conquer.gameview
         Vector2 positionInWorldCoordinates;
         private int imageIndex;
         private string textureKey;
-        public int numSlotsOccupied = 0;
+//        private Boolean slotOccupied0 = false;
+//        private Boolean slotOccupied1 = false;
+//        private Boolean slotOccupied2 = false;
+//        private Boolean slotOccupied3 = false;
+//        private Boolean slotOccupied4 = false;
 
-        public  BasicMapSquare(int x, int y, string textureKey, int imageIndex )
+        private Minigunner minigunnerSlot0 = null;
+        private Minigunner minigunnerSlot1 = null;
+        private Minigunner minigunnerSlot2 = null;
+        private Minigunner minigunnerSlot3 = null;
+        private Minigunner minigunnerSlot4 = null;
+
+        public BasicMapSquare(int x, int y, string textureKey, int imageIndex )
         {
             this.positionInWorldCoordinates = new Vector2(x,y);
             this.gameSprite = new GameSprite(textureKey);
@@ -71,13 +82,44 @@ namespace mike_and_conquer.gameview
             return new Point((int) positionInWorldCoordinates.X, (int) positionInWorldCoordinates.Y);
         }
 
-        public Point GetNextAvailableMinigunnerPosition()
+        public Point GetDestinationSlotForMinigunner(Minigunner aMinigunner)
         {
 
-            Point center = GetCenter();
-            center.X += 10;
-            center.Y -= 10;
-            return center;
+            Point nextAvailablePosition = GetCenter();
+            if (minigunnerSlot0 == null)
+            {
+                nextAvailablePosition.X = nextAvailablePosition.X + 4;
+                nextAvailablePosition.Y = nextAvailablePosition.Y - 3;
+                minigunnerSlot0 = aMinigunner;
+            }
+            else if (minigunnerSlot1 == null) 
+            {
+                nextAvailablePosition.X = nextAvailablePosition.X - 8;
+                nextAvailablePosition.Y = nextAvailablePosition.Y - 3;
+                minigunnerSlot1 = aMinigunner;
+            }
+            else if (minigunnerSlot2 == null)
+            {
+                nextAvailablePosition.X = nextAvailablePosition.X + 4;
+                nextAvailablePosition.Y = nextAvailablePosition.Y + 10;
+                minigunnerSlot2 = aMinigunner;
+            }
+            else if (minigunnerSlot3 == null)
+            {
+                nextAvailablePosition.X = nextAvailablePosition.X - 8;
+                nextAvailablePosition.Y = nextAvailablePosition.Y + 10;
+                minigunnerSlot3 = aMinigunner;
+            }
+            else if (minigunnerSlot4 == null)
+            {
+                nextAvailablePosition.X = nextAvailablePosition.X - 2;
+                nextAvailablePosition.Y = nextAvailablePosition.Y + 3;
+                minigunnerSlot4 = aMinigunner;
+
+            }
+
+            return nextAvailablePosition;
+
         }
 
         public bool IsBlockingTerrain()

--- a/mike-and-conquer/gameview/BasicMapSquare.cs
+++ b/mike-and-conquer/gameview/BasicMapSquare.cs
@@ -17,17 +17,9 @@ namespace mike_and_conquer.gameview
     {
         public GameSprite gameSprite;
 
-
-
         Vector2 positionInWorldCoordinates;
         private int imageIndex;
         private string textureKey;
-//        private Boolean slotOccupied0 = false;
-//        private Boolean slotOccupied1 = false;
-//        private Boolean slotOccupied2 = false;
-//        private Boolean slotOccupied3 = false;
-//        private Boolean slotOccupied4 = false;
-
         private Minigunner minigunnerSlot0 = null;
         private Minigunner minigunnerSlot1 = null;
         private Minigunner minigunnerSlot2 = null;
@@ -88,6 +80,9 @@ namespace mike_and_conquer.gameview
             Point nextAvailablePosition = GetCenter();
             if (minigunnerSlot0 == null)
             {
+                // TODO:  These slot offsets where determined by trial and error.  
+                // May want to revisit and see if there is some formula
+                // that can be used to calculate them instead of hard coding them...
                 nextAvailablePosition.X = nextAvailablePosition.X + 4;
                 nextAvailablePosition.Y = nextAvailablePosition.Y - 3;
                 minigunnerSlot0 = aMinigunner;

--- a/mike-and-conquer/gameview/BasicMapSquare.cs
+++ b/mike-and-conquer/gameview/BasicMapSquare.cs
@@ -21,12 +21,13 @@ namespace mike_and_conquer.gameview
         Vector2 positionInWorldCoordinates;
         private int imageIndex;
         private string textureKey;
+        public int numSlotsOccupied = 0;
 
         public  BasicMapSquare(int x, int y, string textureKey, int imageIndex )
         {
             this.positionInWorldCoordinates = new Vector2(x,y);
             this.gameSprite = new GameSprite(textureKey);
-            this.gameSprite.drawBoundingRectangle = true;
+            this.gameSprite.drawBoundingRectangle = false;
             this.imageIndex = imageIndex;
             this.textureKey = textureKey;
             SetupAnimations();
@@ -68,6 +69,15 @@ namespace mike_and_conquer.gameview
         public Point GetCenter()
         {
             return new Point((int) positionInWorldCoordinates.X, (int) positionInWorldCoordinates.Y);
+        }
+
+        public Point GetNextAvailableMinigunnerPosition()
+        {
+
+            Point center = GetCenter();
+            center.X += 10;
+            center.Y -= 10;
+            return center;
         }
 
         public bool IsBlockingTerrain()

--- a/mike-and-conquer/gameview/UnitSelectionBox.cs
+++ b/mike-and-conquer/gameview/UnitSelectionBox.cs
@@ -174,11 +174,19 @@ namespace mike_and_conquer.gameview
 
         public void HandleEndDragSelect()
         {
+
+            // TODO:  For now, limiting the number of allowed selected units to 5
+            // Until can add ability to handle the case where more than 5 unites are directed
+            // to move to the same square (i.e. add code to shunt some of the selected units off to nearby squares, since
+            // a single square can only hold 5 minigunners
+            int numMinigunnersSelected = 0;
+            int maxAllowedSelected = 5;
             foreach (Minigunner minigunner in MikeAndConquerGame.instance.gameWorld.gdiMinigunnerList)
             {
-                if (selectionBoxRectangle.Contains(minigunner.positionInWorldCoordinates))
+                if (numMinigunnersSelected < maxAllowedSelected && selectionBoxRectangle.Contains(minigunner.positionInWorldCoordinates))
                 {
                     minigunner.selected = true;
+                    numMinigunnersSelected++;
                 }
                 else
                 {

--- a/mike-and-conquer/main/MikeAndConquerGame.cs
+++ b/mike-and-conquer/main/MikeAndConquerGame.cs
@@ -132,8 +132,11 @@ namespace mike_and_conquer
             else
             {
                 graphics.IsFullScreen = false;
-                graphics.PreferredBackBufferWidth = 1280;
-                graphics.PreferredBackBufferHeight = 1024;
+                //                graphics.PreferredBackBufferWidth = 1280;
+                //                graphics.PreferredBackBufferHeight = 1024;
+                graphics.PreferredBackBufferWidth = 1024;
+                graphics.PreferredBackBufferHeight = 768;
+
             }
 
             Content.RootDirectory = "Content";
@@ -201,6 +204,14 @@ namespace mike_and_conquer
                 AddGdiMinigunnerAtMapSquareCoordinates(new Point(8, 3));
 
                 AddNodMinigunnerAtMapSquareCoordinates(new Point(10, 3), aiIsOn);
+
+
+                AddGdiMinigunnerAtMapSquareCoordinates(new Point(15, 16));
+                AddGdiMinigunnerAtMapSquareCoordinates(new Point(16, 16));
+                AddGdiMinigunnerAtMapSquareCoordinates(new Point(17, 16));
+                AddGdiMinigunnerAtMapSquareCoordinates(new Point(17, 15));
+                AddGdiMinigunnerAtMapSquareCoordinates(new Point(18, 16));
+
 
                 AddSandbag(10, 6, 5);
                 AddSandbag(10, 7, 5);

--- a/mike-and-conquer/main/MikeAndConquerGame.cs
+++ b/mike-and-conquer/main/MikeAndConquerGame.cs
@@ -118,8 +118,8 @@ namespace mike_and_conquer
             this.testMode = testMode;
             graphics = new GraphicsDeviceManager(this);
 
-//            bool makeFullscreen = true;
-            bool makeFullscreen = false;
+            bool makeFullscreen = true;
+//            bool makeFullscreen = false;
             if (makeFullscreen)
             {
                 graphics.IsFullScreen = true;

--- a/mike-and-conquer/main/MikeAndConquerGame.cs
+++ b/mike-and-conquer/main/MikeAndConquerGame.cs
@@ -118,8 +118,8 @@ namespace mike_and_conquer
             this.testMode = testMode;
             graphics = new GraphicsDeviceManager(this);
 
-            bool makeFullscreen = true;
-//            bool makeFullscreen = false;
+//            bool makeFullscreen = true;
+            bool makeFullscreen = false;
             if (makeFullscreen)
             {
                 graphics.IsFullScreen = true;


### PR DESCRIPTION
Currently limiting to selecting only 5 units, so not addressing shunting units to nearby square when more than 5 are selected.  Will add that later